### PR TITLE
Canonicalize shape variants to maximize deduplication

### DIFF
--- a/examples/nurikabe.py
+++ b/examples/nurikabe.py
@@ -35,8 +35,8 @@ def constrain_sea(sym, sg, rc):
   sea_id = Int("sea-id")
   sg.solver.add(sea_id >= 0)
   sg.solver.add(sea_id < HEIGHT * WIDTH)
-  for (y, x) in GIVENS:
-    sg.solver.add(sea_id != rc.location_to_region_id((y, x)))
+  for p in GIVENS:
+    sg.solver.add(sea_id != rc.location_to_region_id(p))
   for y in range(HEIGHT):
     for x in range(WIDTH):
       sg.solver.add(Implies(
@@ -71,8 +71,8 @@ def constrain_islands(sym, sg, rc):
         sg.solver.add(rc.region_size_grid[y][x] == GIVENS[(y, x)])
       else:
         # Ensure that cells that are part of island regions are colored white.
-        for (gy, gx) in GIVENS:
-          island_id = rc.location_to_region_id((gy, gx))
+        for gp in GIVENS:
+          island_id = rc.location_to_region_id(gp)
           sg.solver.add(Implies(
               rc.region_id_grid[y][x] == island_id,
               sg.cell_is(y, x, sym.W)

--- a/examples/spiral_galaxies.py
+++ b/examples/spiral_galaxies.py
@@ -65,7 +65,7 @@ def main():
         )
       sg.solver.add(Or(*or_terms))
 
-  def show_cell(y, x, region_id):
+  def show_cell(y, x, region_id): # pylint: disable=unused-argument
     ry, rx = rc.region_id_to_location(region_id)
     for i, (gy, gx) in enumerate(GIVENS):
       if int(math.floor(gy)) == ry and int(math.floor(gx)) == rx:

--- a/examples/tapa.py
+++ b/examples/tapa.py
@@ -149,8 +149,8 @@ def main():
       sg.solver.add(Not(And(*[cell == SYM.B for cell in pool_cells])))
 
   # Add constraints for the given clues.
-  for (y, x) in GIVENS:
-    add_neighbor_constraints(sg, y, x)
+  for p in GIVENS:
+    add_neighbor_constraints(sg, p[0], p[1])
 
   def show_cell(y, x, _):
     given = GIVENS.get((y, x))

--- a/grilops/shapes.py
+++ b/grilops/shapes.py
@@ -15,12 +15,7 @@ def rotate_shape_clockwise(shape):
   (List[Tuple[int, int]]): A list of (y, x) coordinates defining the 90-degree
       clockwise rotation of the input shape.
   """
-  min_y = min(p[0] for p in shape)
-  max_y = max(p[0] for p in shape)
-  rotated_shape = []
-  for y, x in shape:
-    rotated_shape.append((x, max_y - min_y - y))
-  return rotated_shape
+  return [(x, -y) for (y, x) in shape]
 
 
 def reflect_shape_y(shape):
@@ -33,12 +28,7 @@ def reflect_shape_y(shape):
   (List[Tuple[int, int]]): A list of (y, x) coordinates defining the vertical
       reflection of the input shape.
   """
-  min_y = min(p[0] for p in shape)
-  max_y = max(p[0] for p in shape)
-  reflected_shape = []
-  for y, x in shape:
-    reflected_shape.append((max_y - min_y - y, x))
-  return reflected_shape
+  return [(-y, x) for (y, x) in shape]
 
 
 def reflect_shape_x(shape):
@@ -51,12 +41,25 @@ def reflect_shape_x(shape):
   (List[Tuple[int, int]]): A list of (y, x) coordinates defining the horizontal
       reflection of the input shape.
   """
-  min_x = min(p[1] for p in shape)
-  max_x = max(p[1] for p in shape)
-  reflected_shape = []
-  for y, x in shape:
-    reflected_shape.append((y, max_x - min_x - x))
-  return reflected_shape
+  return [(y, -x) for (y, x) in shape]
+
+
+def canonicalize_shape(shape):
+  """Returns a new shape that's canonicalized, i.e., it's in sorted order
+  and its first point is (0, 0).  This helps with deduplication, since
+  equivalent shapes will be canonicalized identically.
+
+  # Arguments:
+  shape (List[Tuple[int, int]]): A list of (y, x) coordinates defining a shape.
+
+  # Returns.
+  (List[Tuple[int, int]]): A list of (y, x) coordinates defining the
+     canonicalized version of the shape, i.e., in sorted order and
+     with first point (0, 0).
+  """
+  shape = sorted(shape)
+  ulp = shape[0]
+  return [(p[0] - ulp[0], p[1] - ulp[1]) for p in shape]
 
 
 class ShapeConstrainer:
@@ -123,7 +126,10 @@ class ShapeConstrainer:
           more_variants.append(reflect_shape_y(variant))
           more_variants.append(reflect_shape_x(variant))
         variants = more_variants
-      variants = [list(s) for s in {tuple(sorted(s)) for s in variants}]
+      variants = [
+          list(s)
+          for s in {tuple(canonicalize_shape(s)) for s in variants}
+      ]
       all_variants.append(variants)
     return all_variants
 


### PR DESCRIPTION
To maximize deduplication opportunities, canonicalize each shape variant so that it's sorted and its first point is (0, 0).  Ensuring the point (0, 0) is always part of each variant may also be useful later if we use irregular and/or non-rectangular grids.

Also, fix a few pylint warnings.
